### PR TITLE
Fix fallback images, opengraph tags

### DIFF
--- a/hugo/content/blog/2022-09-29/index.md
+++ b/hugo/content/blog/2022-09-29/index.md
@@ -35,8 +35,8 @@ featureImage: 'refreshing-may_flickr-blavandmaster.jpg' # Top image on post.
 featureImageAlt: 'Refreshing May' # Alternative text for featured image.
 featureImageCreditFlickr: 'blavandmaster'
 # featureImageCreditCustom: 'Top image credit Flickr user [username](https://www.flickr.com/photos/username).'
-thumbnail: 'refreshing-may_flickr-blavandmaster.jpg' # Image in lists of posts.
-shareImage: 'refreshing-may_flickr-blavandmaster.jpg' # For SEO and social media snippets. Falls back to thumbnail (if set) or featureImage.
+# thumbnail: 'thumbnail.jpg' # Image in lists of posts.
+# shareImage: 'share.jpg' # For SEO and social media snippets. Falls back to thumbnail (if set) or featureImage.
 
 codeMaxLines: 10 # Override global value for how many lines within a code block before auto-collapsing.
 codeLineNumbers: false # Override global value for showing of line numbers within code block.

--- a/hugo/layouts/partials/excerpt.html
+++ b/hugo/layouts/partials/excerpt.html
@@ -7,6 +7,12 @@
   - Adding visually-hidden titles to "read more" links
   - Restructuring 'with .Params.thumbnail' so linters won't complain
 */}}
+{{- $thumbnail := .Params.featureImage -}}
+{{- with .Params.thumbnail -}}
+  {{- $thumbnail = . -}}
+{{- end -}}
+
+
 <li class="post_item">
   <div class="excerpt">
     <div class="excerpt_header">
@@ -26,13 +32,19 @@
       <div
         class="
         excerpt_footer
-        {{ with .Params.thumbnail }}partition{{ end }}
+        {{ with $thumbnail }}partition{{ end }}
       "
       >
         <div class="excerpt_summary">
-          {{- with .Params.thumbnail -}}
+          {{- with $thumbnail -}}
             <div class="excerpt_thumbnail">
-              {{- partial "image" (dict "file" . "alt" $.Title "type" "thumbnail" "Page" $.Page ) }}
+              {{- partial "image" (dict
+                "file" .
+                "alt" $.Title
+                "type" "thumbnail"
+                "Page" $.Page
+                )
+              }}
             </div>
           {{- else -}}
             <div class="excerpt_thumbnail excerpt_thumbnail--none"></div>

--- a/hugo/layouts/partials/function/vars/getSummary.html
+++ b/hugo/layouts/partials/function/vars/getSummary.html
@@ -28,6 +28,6 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- $summary = strings.Trim $summary "\n" -}}
+{{- $summary = strings.Trim $summary "\n" | safeHTML -}}
 
 {{- return $summary -}}

--- a/hugo/layouts/partials/function/vars/getTitle.html
+++ b/hugo/layouts/partials/function/vars/getTitle.html
@@ -23,6 +23,8 @@
   {{- end -}}
 {{- end -}}
 
+{{- $title := $title | safeHTML -}}
+
 {{- $title_link := printf "%s" "</a>" | printf "%s%s" $title | printf "%s%s" `">` | printf "%s%s" .Permalink | printf "%s%s" `<a href="` | printf "%s" -}}
 
 {{- $title := dict


### PR DESCRIPTION
- Fixes #14 
- Ensures summaries and titles aren't HTML-escaped