### PR TITLE
Corrections to generated feeds

### DIFF
--- a/hugo/layouts/partials/function/vars/getContent.html
+++ b/hugo/layouts/partials/function/vars/getContent.html
@@ -5,8 +5,6 @@
 */}}
 
 {{- $s := .Site.Params -}}
-{{- $title := partial "function/vars/getTitle" . -}}
-{{- $path := partial "function/vars/getPath" . -}}
 
 {{/* Regular content */}}
 
@@ -21,9 +19,11 @@
 {{- $feed_html := strings.Trim .Content "\n" -}}
 {{- $feed_html = partial "function/absurlify" (dict "ctx" . "content" $feed_html) -}}
 {{- $feed_html = partial "function/entify" $feed_html -}}
+{{- $feed_html = replace $feed_html "\n" " " -}}
 
 {{- $feed_plain := .Plain -}}
 {{- $feed_plain := strings.Trim $plain "\n" -}}
+{{- $feed_plain = replace $feed_plain "\n" " " -}}
 
 {{- $content := dict
   "lang"         .Language.Lang

--- a/hugo/layouts/partials/function/vars/getTitle.html
+++ b/hugo/layouts/partials/function/vars/getTitle.html
@@ -23,7 +23,7 @@
   {{- end -}}
 {{- end -}}
 
-{{- $title := $title | safeHTML -}}
+{{- $title := (htmlEscape $title) | safeHTML -}}
 
 {{- $title_link := printf "%s" "</a>" | printf "%s%s" $title | printf "%s%s" `">` | printf "%s%s" .Permalink | printf "%s%s" `<a href="` | printf "%s" -}}
 


### PR DESCRIPTION
- replacing linebreaks within content with spaces, so that lines don't get run together in some contexts
- html-escaping titles to prevent feed parsing errors